### PR TITLE
allow combining tag filtering and path filtering

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -135,12 +135,33 @@ fi
 
 if [ -n "$tag_filter" ]; then
   {
-    if [ -n "$ref" ] && [ -n "$branch" ]; then
-      tags=$(git tag --list "$tag_filter" --sort=creatordate --contains $ref --merged $branch)
-      get_commit $tags
-    elif [ -n "$ref" ]; then
-      tags=$(git tag --list "$tag_filter" --sort=creatordate | lines_including_and_after $ref)
-      get_commit $tags
+    if [ -n "$ref" ]; then
+      if [ -n "$branch" ]; then
+        tags=$(git tag --list "$tag_filter" --sort=creatordate --merged $branch | lines_including_and_after $ref)
+      else
+        tags=$(git tag --list "$tag_filter" --sort=creatordate | lines_including_and_after $ref)
+      fi
+      if [ -n "$tags" -a -n "$paths_search" ]; then
+        original_tags="$tags"
+        tags=""
+        for tag in $original_tags; do
+          # find the most recent commit that matches the search path
+          path_commit=$(git rev-list -n 1 $tag $paths_search)
+          if [ -z "$path_commit" ]; then
+            continue
+          fi
+          tag_commit=$(git rev-list -n 1 $tag)
+          if [ "$tag_commit" != "$path_commit" ]; then
+            # exclude the tag if another tag is closer to the commit
+            other_tag_commit=$(git rev-list -n 1 $(git tag --list "$tag_filter" --sort=creatordate --contains $path_commit | head -n 1))
+            if [ "$tag_commit" != "$other_tag_commit" ]; then
+              continue
+            fi
+          fi
+          tags="$tags$tag\n"
+        done
+      fi
+      get_commit "$(echo -e "$tags")"
     else
       branch_flag=
       if [ -n "$branch" ]; then

--- a/test/check.sh
+++ b/test/check.sh
@@ -689,6 +689,25 @@ it_can_check_with_tag_filter_given_branch_first_ref() {
   "
 }
 
+it_can_check_with_tag_filter_given_paths() {
+  local repo=$(init_repo)
+  local ref1=$(make_commit_to_file_on_branch_with_path $repo path-a file-a master "path-a/file-a on master")
+  local ref2=$(make_annotated_tag $repo "test.tag.1" "tag 1")
+  local ref3=$(make_commit_to_file_on_branch_with_path $repo path-b file-b1 master "path-b/file-b on master")
+  local ref4=$(make_annotated_tag $repo "test.tag.2" "tag 1")
+  local ref5=$(make_commit_to_file_on_branch_with_path $repo path-b file-b2 master "path-b/file-b on master")
+  local ref6=$(make_annotated_tag $repo "test.tag.3" "tag 1")
+
+  check_uri_with_tag_filter_from_given_paths $repo "test.tag.*" "$ref2" "path-b" | jq -e "
+    . == [{ref: \"test.tag.2\", commit: \"$ref3\"},{ref: \"test.tag.3\", commit: \"$ref5\"}]
+  "
+
+  # select the older commit with a file match
+  check_uri_with_tag_filter_from_given_paths $repo "test.tag.*" "$ref2" "path-b/file-b1" | jq -e "
+    . == [{ref: \"test.tag.2\", commit: \"$ref3\"}]
+  "
+}
+
 it_can_check_and_set_git_config() {
   local repo=$(init_repo)
   local ref=$(make_commit $repo)
@@ -783,3 +802,4 @@ run it_can_check_from_a_ref_with_paths_merged_in
 run it_can_check_with_tag_filter_given_branch_first_ref
 run it_checks_lastest_commit
 run it_can_check_a_repo_having_multiple_root_commits
+run it_can_check_with_tag_filter_given_paths

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -504,6 +504,23 @@ check_uri_with_tag_filter_from() {
   }" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_with_tag_filter_from_given_paths() {
+  local uri=$1
+  local tag_filter=$2
+  local ref=$3
+  local paths=$4
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      tag_filter: $(echo $tag_filter | jq -R .),
+      paths: [$(echo $paths | jq -R .)],
+    },
+    version: {
+      ref: $(echo $ref | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}
+
 check_uri_with_config() {
   jq -n "{
     source: {


### PR DESCRIPTION
given a commit matching path filter:
1. find the oldest tag that matches tag_filter that contains the commit
2. get the commit for the tag and find all tags matching tag_filter that point at the commit